### PR TITLE
fix(formatSingleValue): defaults toString and call func on arrays of …

### DIFF
--- a/src/services/message-service.ts
+++ b/src/services/message-service.ts
@@ -415,13 +415,15 @@ const recurseFormatDisplayValue = (
       typeof value
     );
     const isArrayOfObjects = isMatching(P.array({}), value);
-    const isArrayOfStringsOrNumbers =
-      isMatching(P.array(P.string), value) || isMatching(P.array(P.number), value);
+    const isArrayOfStringsOrNumbersOrBools =
+      isMatching(P.array(P.string), value) ||
+      isMatching(P.array(P.string), value) ||
+      isMatching(P.array(P.boolean), value);
 
     let currentFormattedValue: any;
     try {
       if (isStringOrNumberOrBool) {
-        currentFormattedValue = formatSingleValue(key, value);
+        currentFormattedValue = formatSingleValue(value);
       } else {
         currentFormattedValue = formatCustomObj(key, value);
       }
@@ -437,10 +439,12 @@ const recurseFormatDisplayValue = (
     }
 
     // Arrays are displayed as space delimited single values or recursed again.
-    if (isArrayOfObjects || isArrayOfStringsOrNumbers) {
+    if (isArrayOfObjects || isArrayOfStringsOrNumbersOrBools) {
       // Array is all string/numbers (combine and display)
-      if (isArrayOfStringsOrNumbers) {
-        const currentFieldCombinedValue = value.join(`\n`);
+      if (isArrayOfStringsOrNumbersOrBools) {
+        const currentFieldCombinedValue = value
+          .map((v) => formatSingleValue(v))
+          .join(`\n`);
         parentKey
           ? (finalFlattenedDisplayObject[parentKey][key] = currentFieldCombinedValue)
           : (finalFlattenedDisplayObject[key] = currentFieldCombinedValue);
@@ -487,5 +491,6 @@ export const formatDisplayObject = ({
       {}
     );
   }
+
   return finalMessage;
 };

--- a/src/utils/display/displayFormattedFields.ts
+++ b/src/utils/display/displayFormattedFields.ts
@@ -73,8 +73,8 @@ export const displayDateAndTime = (fieldValue: string) => {
  * function again.
  *
  */
-export const formatSingleValue = (key: string, value: any) =>
-  match({ key, value })
+export const formatSingleValue = (value: any) =>
+  match({ value })
     // True => Yes, False => No
     .with({ value: P.boolean }, () => (value ? 'Yes' : 'No'))
     // Attempt to convert number or string to a Date
@@ -89,7 +89,8 @@ export const formatSingleValue = (key: string, value: any) =>
       {
         value: P.when(
           (str: any) =>
-            str.indexOf('tp') === 0 || (str.indexOf(' ') < 0 && str.length > 30)
+            str.toString().indexOf('tp') === 0 ||
+            (str.toString().indexOf(' ') < 0 && str.length > 30)
         ),
       },
       () => displayAddress(value)
@@ -102,8 +103,7 @@ export const formatSingleValue = (key: string, value: any) =>
       () => displayCapitalizedString(value)
     )
     // Default print as string
-    .with({ value: P.string || P.number }, () => value.toString())
-    .otherwise(() => null);
+    .otherwise(() => value.toString());
 
 /**
  * Deduce the formatting function based on the field and/or value. Value


### PR DESCRIPTION
- calls `formatSingleValue` on each single value in arrays reduced to space delimited strings
- removes unused `key` param from function
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer