### PR TITLE
Add new type MsgExec in switch statement

### DIFF
--- a/src/services/messages/build/buildMessage.ts
+++ b/src/services/messages/build/buildMessage.ts
@@ -51,9 +51,9 @@ import {
   MsgCreateGroup,
   MsgSubmitProposal as MsgSubmitGroupProposal,
   MsgVote as MsgGroupVote,
+  MsgExec as MsgGroupExec,
 } from '../../../proto/cosmos/group/v1/tx_pb';
 import { MemberRequest } from '../../../proto/cosmos/group/v1/types_pb';
-
 const encoder = new TextEncoder();
 
 /**
@@ -173,6 +173,14 @@ export const buildMessage = (
         .setExec(exec)
         .setMetadata(metadata);
       return msgGroupVote;
+    }
+
+    case 'MsgExec': {
+      const { proposalId, executor } = params as MsgExecDisplay;
+      const msgExec = new MsgGroupExec()
+        .setProposalId(proposalId)
+        .setExecutor(executor);
+      return msgExec;
     }
 
     case 'MsgInstantiateContract': {


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
This allows consumers to run buildMessage with the type MsgExec
closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer